### PR TITLE
Ajustes-docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 # Dockerfile
-# -----------
 
 FROM python:3.12-slim
 
@@ -13,16 +12,19 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
     GUNICORN_WORKERS=4 \
     GUNICORN_THREADS=8
 
-# Cria diretório /app (usado pela aplicação) e define permissões
-RUN mkdir -p /app \
-    && chown -R 1000:1000 /app
+# Cria diretorios /tgdmserver e /tgdmserver/upload. Define suas permissoes
+    RUN mkdir -p /tgdmserver /tgdmserver/upload \
+    && chown -R 1000:1000 /tgdmserver \
+    && chown -R 1000:1000 /tgdmserver/upload \
+    && chmod -R 664 /tgdmserver/upload
+
 
 # Instala dependências do sistema (GDAL, Spatialite, PostgreSQL dev, etc.)
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-       gdal-bin libgdal-dev python3-gdal \
-       sqlite3 libsqlite3-mod-spatialite \
-       build-essential libpq-dev \
+    gdal-bin libgdal-dev python3-gdal \
+    sqlite3 libsqlite3-mod-spatialite \
+    build-essential libpq-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # Copia e instala dependências Python (incluindo Gunicorn)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,12 +38,15 @@ services:
       POSTGRES_DB: geodata
     ports:
       - "8000:8000"
+    volumes:
+      - tgdmserver:/tgdmserver
     networks:
       - terra_network
     restart: unless-stopped
 
 volumes:
   postgres_data:
+  tgdmserver:
 
 networks:
   terra_network:

--- a/import_data_to_postgres.py
+++ b/import_data_to_postgres.py
@@ -1,6 +1,6 @@
-# import_data_to_postgresa.py
-
 #!/usr/bin/env python3
+
+# import_data_to_postgresa.py
 
 import os
 import subprocess
@@ -125,7 +125,7 @@ def import_municipios(geojson_path: str):
 
 
 def main():
-    import_malha_fundiaria("data/dataset-malha-fundiaria-idace_preprocessado-2025-06-06.csv")
+    import_malha_fundiaria("data/dataset-malha-fundiaria-idace_preprocessado-2025-06-26.csv")
     import_municipios("data/geojson-municipios_ceara-normalizado.geojson")
     print("✅ Importação completa!")
 


### PR DESCRIPTION
Foram corrigidos os nomes de volume do server (Dockerfile), que estavam dessacociados, No Dockerfile. No caso, O WORKDIR" estava como "tgdmserver" e na criação ("RUN mkdir -p"), estava como "/app". Só estava funcionando pois a cópia dos arquivos "funcionando" por um mistério da natureza. 

Foi criado o diretório "/tgdmserver/upload", para geração dos shapefiles.

No docker-compose.yml, foi deixado explícito o volume usado pelo server, no caso, o "/tgdmserver", que foi identificado como volume "tgdmserver". 